### PR TITLE
Add WeakSet to prevent double dispose

### DIFF
--- a/JavaScript/7-ref-count.js
+++ b/JavaScript/7-ref-count.js
@@ -9,6 +9,7 @@ class RefCount {
   #dispose = null;
   #context = null;
   #count = 0;
+  #freed = new WeakSet();
 
   constructor(create, dispose) {
     this.#dispose = dispose;
@@ -27,6 +28,8 @@ class RefCount {
     this.#count++;
     const disposable = Object.create(this.#resource);
     disposable[Symbol.asyncDispose] = async () => {
+      if (this.#freed.has(disposable)) return;
+      this.#freed.add(disposable);
       console.log('👉 Dispose');
       this.#count--;
       if (this.#count > 0) return;


### PR DESCRIPTION
Manually calling `console[Symbol.asyncDispose]()` caused a double dispose (disposing the resource twice), leading to errors and unstable behavior.

In earlier versions, the following example did not work correctly:

```javascript
 // Block 0
 {
    await using console = logger.use();
    console.log('Log 1');

    // Manually calling dispose causes double dispose error:
    console[Symbol.asyncDispose]();

    // Block 1
    {
      await using console = logger.use();
      console.log('Log 1');
    }
    // Block 2
    {
      await using console = logger.use();
      console.log('Log 2');
    }
    await timers.setTimeout(1000);
  }
 ```
 
 The above example now works without issues, and double dispose errors are prevented.